### PR TITLE
Remove serviceName and instanceId from reference.conf

### DIFF
--- a/libats-metrics/src/main/resources/reference.conf
+++ b/libats-metrics/src/main/resources/reference.conf
@@ -7,8 +7,6 @@ ats {
     port = ${?INFLUXDB_PORT}
     database = "services"
     database = ${?METRICS_DB}
-    serviceName = ${serviceName}
-    instanceId = ${instanceId}
     interval = 5s
   }
 }


### PR DESCRIPTION
Removing them here will force user of the lib to set values in
application.conf. Having default values here is dangerous because
if they are not changed metrics from different services will be
mixed.