### PR TITLE
[PRO-3533] Update DeviceUpdateReport event

### DIFF
--- a/libats-messaging-datatype/src/test/scala/com/advancedtelematic/libats/messaging_data/CodecSpec.scala
+++ b/libats-messaging-datatype/src/test/scala/com/advancedtelematic/libats/messaging_data/CodecSpec.scala
@@ -1,0 +1,56 @@
+package com.advancedtelematic.libats.messaging_datatype
+
+import cats.syntax.show._
+import com.advancedtelematic.libats.data.Namespace
+import com.advancedtelematic.libats.data.RefinedUtils._
+import com.advancedtelematic.libats.messaging_datatype.DataType._
+import com.advancedtelematic.libats.messaging_datatype.MessageCodecs._
+import com.advancedtelematic.libats.messaging_datatype.Messages._
+import io.circe.syntax._
+import io.circe.parser.decode
+import org.scalatest.{FunSuite, Matchers}
+
+class CodecSpec extends FunSuite with Matchers {
+
+  val targetA = "target-a".refineTry[ValidTargetFilename].get
+  val hashA = Map(HashMethod.SHA256 -> "0a79a6bef63c2205d4c6dac360b4b4600366f695bb18b5e3eec4e2297df50666".refineTry[ValidChecksum].get)
+
+  val operationResultOk =
+    OperationResult(targetA, hashA, 22, 0, "OK")
+
+  val operationResultFailed =
+    OperationResult(targetA, hashA, 22, 19, "Failed")
+
+  val ecu1 = "ecu1".refineTry[ValidEcuSerial].get
+  val ecu2 = "ecu2".refineTry[ValidEcuSerial].get
+
+  val device = DeviceId.generate
+  val update = UpdateId.generate
+
+  val deviceUpdateReportOk =
+    DeviceUpdateReport(Namespace("ns"), device, update, 1,
+                       Map(ecu1 -> operationResultOk, ecu2 -> operationResultOk),
+                       0)
+
+  val deviceUpdateReportFailed =
+    DeviceUpdateReport(Namespace("ns"), device, update, 1,
+                       Map(ecu1 -> operationResultOk, ecu2 -> operationResultFailed),
+                       19)
+
+  test("encode/decode for DeviceUpdateReport") {
+    decode[DeviceUpdateReport](deviceUpdateReportOk.asJson.noSpaces) shouldBe Right(deviceUpdateReportOk)
+    decode[DeviceUpdateReport](deviceUpdateReportFailed.asJson.noSpaces) shouldBe Right(deviceUpdateReportFailed)
+  }
+
+  test("decode DeviceUpdateReport without statusCode") {
+    val opOkay = operationResultOk.asJson.noSpaces
+    val opFail = operationResultFailed.asJson.noSpaces
+
+    val ok = s"""{"namespace": "ns", "device": "${device.show}", "updateId": "${update.show}", "timestampVersion": 1, "operationResult": {"ecu1": $opOkay, "ecu2": $opOkay}}"""
+
+    val failed = s"""{"namespace": "ns", "device": "${device.show}", "updateId": "${update.show}", "timestampVersion": 1, "operationResult": {"ecu1": $opOkay, "ecu2": $opFail}}"""
+
+    decode[DeviceUpdateReport](ok) shouldBe Right(deviceUpdateReportOk)
+    decode[DeviceUpdateReport](failed) shouldBe Right(deviceUpdateReportFailed)
+  }
+}


### PR DESCRIPTION
The event DeviceUpdateReport should have a new field statusCode
which is a result code for the whole device.

For backward compatibility we use a custom decoder that if a statusCode
is not present we interpret all ecus succeding as success (0 OK) otherwise
it is an error (19 GENERAL_ERROR).