### PR TITLE
fix refined codec, again

### DIFF
--- a/libats/src/main/scala/com/advancedtelematic/libats/codecs/CirceRefined.scala
+++ b/libats/src/main/scala/com/advancedtelematic/libats/codecs/CirceRefined.scala
@@ -4,17 +4,19 @@ import eu.timepit.refined.api.{Refined, Validate}
 import eu.timepit.refined.refineV
 import io.circe.{Decoder, Encoder}
 
+import scala.util.{Failure, Success}
+
 trait CirceRefined {
   implicit def refinedEncoder[T, P](implicit encoder: Encoder[T]): Encoder[Refined[T, P]] =
     encoder.contramap(_.value)
 
   implicit def refinedDecoder[T, P](implicit decoder: Decoder[T], p: Validate.Plain[T, P]): Decoder[Refined[T, P]] =
-    decoder.map(t =>
+    decoder.emapTry { t =>
       refineV[P](t) match {
-        case Left(e)  =>
-          throw DeserializationException(RefinementError(t, e))
-        case Right(r) => r
-      })
+        case Left(e) => Failure(DeserializationException(RefinementError(t, e)))
+        case Right(r) => Success(r)
+      }
+    }
 }
 
 object CirceRefined extends CirceRefined


### PR DESCRIPTION
This prevented us from using `_.as[Refined[_, _]] orElse` for example, because an exception was thrown instead of a Left returned.