### PR TITLE
Add /health/dependencies endpoint to health check resource

### DIFF
--- a/libats-http/src/main/scala/com/advancedtelematic/libats/http/monitoring/HealthCheckHttpClient.scala
+++ b/libats-http/src/main/scala/com/advancedtelematic/libats/http/monitoring/HealthCheckHttpClient.scala
@@ -1,0 +1,37 @@
+package com.advancedtelematic.libats.http.monitoring
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpRequest, HttpResponse}
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+import akka.stream.Materializer
+import io.circe.Json
+
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.util.control.NoStackTrace
+import io.circe.syntax._
+import cats.syntax.either._
+
+abstract class HealthCheckHttpClient(implicit val system: ActorSystem, mat: Materializer, ec: ExecutionContext) {
+  import HealthCheckHttpClient._
+
+  lazy val _http = Http()
+
+  protected def execute(request: HttpRequest): Future[Json] =
+    _http.singleRequest(request).flatMap {
+      case r @ HttpResponse(status, _, _, _) if status.isSuccess() =>
+        jsonUnmarshaller(r.entity)
+      case r =>
+        Future.failed(HealthCheckError(s"Unexpected response from service: $r"))
+    }
+
+  private val jsonUnmarshaller =
+    Unmarshaller
+      .stringUnmarshaller
+      .forContentTypes(ContentTypes.`application/json`)
+      .map { data => io.circe.parser.parse(data).valueOr(throw _) }
+}
+
+object HealthCheckHttpClient {
+  case class HealthCheckError(str: String) extends Throwable(str) with NoStackTrace
+}

--- a/libats-http/src/main/scala/com/advancedtelematic/libats/http/monitoring/ServiceHealthCheck.scala
+++ b/libats-http/src/main/scala/com/advancedtelematic/libats/http/monitoring/ServiceHealthCheck.scala
@@ -1,0 +1,28 @@
+package com.advancedtelematic.libats.http.monitoring
+
+import akka.actor.ActorSystem
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest, Uri}
+import akka.stream.Materializer
+import com.advancedtelematic.libats.http.HealthCheck
+import com.advancedtelematic.libats.http.HealthCheck.{Down, HealthCheckResult, Up}
+import io.circe.syntax._
+import cats.syntax.either._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ServiceHealthCheck(address: Uri)(implicit system: ActorSystem, mat: Materializer, ec: ExecutionContext) extends HealthCheckHttpClient with HealthCheck {
+  override def apply(logger: LoggingAdapter)(implicit ec: ExecutionContext): Future[HealthCheckResult] = {
+    val req = HttpRequest(HttpMethods.GET, address.withPath(Path("/health")))
+    execute(req)
+      .map(_ => Up)
+      .recover {
+        case ex =>
+          logger.error(ex, s"service $address is down")
+          Down(ex)
+      }
+  }
+
+  override def name: String = address.toString()
+}

--- a/libats-http/src/main/scala/com/advancedtelematic/libats/http/monitoring/VaultHealthCheck.scala
+++ b/libats-http/src/main/scala/com/advancedtelematic/libats/http/monitoring/VaultHealthCheck.scala
@@ -1,0 +1,64 @@
+package com.advancedtelematic.libats.http.monitoring
+
+import akka.actor.ActorSystem
+import akka.event.LoggingAdapter
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.Uri.Path
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.unmarshalling.Unmarshaller
+import akka.stream.Materializer
+import com.advancedtelematic.libats.http.HealthCheck
+import com.advancedtelematic.libats.http.HealthCheck.{Down, HealthCheckResult, Up}
+import com.advancedtelematic.libats.http.monitoring.HealthCheckHttpClient.HealthCheckError
+import io.circe.Json
+
+import scala.concurrent.{ExecutionContext, Future}
+
+
+class VaultHealthCheck(address: Uri, token: String)(implicit system: ActorSystem, mat: Materializer, ec: ExecutionContext)
+  extends HealthCheckHttpClient with HealthCheck {
+  import cats.syntax.either._
+
+  override def apply(logger: LoggingAdapter)(implicit ec: ExecutionContext): Future[HealthCheckResult] = {
+    val checkF = for {
+      _ <- sysHealth()
+      _ <- tokenLookup()
+    } yield Up
+
+    checkF.recover {
+      case ex =>
+        logger.error(ex, "Vault is down")
+        Down(ex)
+    }
+  }
+
+  private def sysHealth(): Future[Json] = {
+    val req = HttpRequest(HttpMethods.GET, address.withPath(Path("/v1") / "sys" / "health"))
+
+    execute(req).flatMap { json =>
+      val vaultSysE = for {
+        isInitialized <- json.hcursor.downField("initialized").as[Boolean].leftMap(_.message)
+        isSealed <- json.hcursor.downField("sealed").as[Boolean].leftMap(_.message)
+        json <- {
+          if(isSealed)
+            Left("vault is sealed")
+          else if(!isInitialized)
+            Left("vault is not initialized")
+          else
+            Right(json)
+        }
+      } yield json
+
+      Future.fromTry(vaultSysE.leftMap(HealthCheckError).toTry)
+    }
+  }
+
+  private def tokenLookup(): Future[Json] = {
+    val req = HttpRequest(HttpMethods.GET, address.withPath(Path("/v1") / "auth" / "token" / "lookup-self"))
+      .addHeader(RawHeader("X-Vault-Token", token))
+    execute(req)
+  }
+
+  override def name: String = s"vault/${address.authority.host}"
+}


### PR DESCRIPTION
Support checking dependencies for services and vault

Added to different endpoint and not /health as that would cause all
connected services to reboot if one services fails.

This endpoint can be used by developers and tools to check services
are properly configured and up.