### PR TITLE
Handle decoding failure on DefaultRejectionHandler

### DIFF
--- a/libats/src/main/scala/com/advancedtelematic/libats/codecs/DeserializationException.scala
+++ b/libats/src/main/scala/com/advancedtelematic/libats/codecs/DeserializationException.scala
@@ -4,8 +4,10 @@
  */
 package com.advancedtelematic.libats.codecs
 
+import scala.util.control.NoStackTrace
+
 /**
  * Unmarshalling into JSON sometimes fails, see CirceMarshallingSupport.scala.
  */
 
-case class DeserializationException(cause: Throwable) extends Throwable(cause)
+case class DeserializationException(cause: Throwable) extends Throwable(cause) with NoStackTrace


### PR DESCRIPTION
Avoids giant stacktrace when decoding invalid refined entity