### PR TITLE
Extend the HttpClient service to execute requests with namespace.

### DIFF
--- a/libats-http/src/main/scala/com/advancedtelematic/libats/http/HttpOps.scala
+++ b/libats-http/src/main/scala/com/advancedtelematic/libats/http/HttpOps.scala
@@ -1,0 +1,14 @@
+package com.advancedtelematic.libats.http
+
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.headers.RawHeader
+import com.advancedtelematic.libats.data.DataType.Namespace
+
+object HttpOps {
+
+  implicit class HttpRequestOps(request: HttpRequest) {
+    def withNs(ns: Namespace): HttpRequest =
+      request.withHeaders(RawHeader("x-ats-namespace", ns.get))
+  }
+
+}


### PR DESCRIPTION
I think it would be nice to add this. Campaigner is using its own implementation of HttpClient, which takes a namespace with the request. If we add this method here I could refactor Campaigner to use this HttpClient and be a bit more consistent across all the microservices.