### PR TITLE
Add libats-logging, json logging support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -169,6 +169,14 @@ lazy val libats_auth = (project in file("libats-auth"))
   .settings(libraryDependencies += Library.akkaSlf4j)
   .dependsOn(libats)
 
+lazy val libats_logging = (project in file("libats-logging"))
+  .enablePlugins(BuildInfoPlugin, Versioning.Plugin)
+  .configs(commonConfigs: _*)
+  .settings(commonSettings)
+  .settings(libraryDependencies ++= Library.circe :+ Library.logback)
+  .settings(name := "libats-logging")
+  .settings(Publish.settings)
+
 lazy val libats_root = (project in file("."))
   .enablePlugins(DependencyGraph)
   .settings(Publish.disable)
@@ -176,4 +184,4 @@ lazy val libats_root = (project in file("."))
   .settings(crossScalaVersions := Seq("2.11.11", "2.12.4"))
   .aggregate(libats, libats_http, libats_messaging, libats_messaging_datatype,
     libats_slick, libats_auth, libats_metrics, libats_metrics_kafka, libats_metrics_akka,
-    libats_metrics_finagle, libats_metrics_prometheus)
+    libats_metrics_finagle, libats_metrics_prometheus, libats_logging)

--- a/libats-http/src/main/resources/reference.conf
+++ b/libats-http/src/main/resources/reference.conf
@@ -1,0 +1,3 @@
+ats {
+  http.logging.router.childCount = 3
+}

--- a/libats-http/src/main/scala/com/advancedtelematic/libats/http/logging/RequestLoggingActor.scala
+++ b/libats-http/src/main/scala/com/advancedtelematic/libats/http/logging/RequestLoggingActor.scala
@@ -1,0 +1,38 @@
+package com.advancedtelematic.libats.http.logging
+
+import akka.actor.{Actor, ActorSystem, DiagnosticActorLogging, Props, SupervisorStrategy}
+import akka.event.Logging
+import akka.event.Logging.MDC
+import akka.routing.RoundRobinPool
+import com.advancedtelematic.libats.http.logging.RequestLoggingActor.LogMsg
+import com.typesafe.config.ConfigFactory
+
+import scala.util.Random
+
+object RequestLoggingActor {
+  case class LogMsg(formattedMsg: String, metrics: Map[String, String])
+
+  private val config = ConfigFactory.load()
+
+  def router(level: Logging.LogLevel)(implicit system: ActorSystem): Props = {
+    val restartStrategy = SupervisorStrategy.defaultStrategy
+    val childCount = config.getInt("ats.http.logging.router.childCount")
+    RoundRobinPool(childCount, supervisorStrategy = restartStrategy).props(props(level))
+  }
+
+  def props(level: Logging.LogLevel) = Props(new RequestLoggingActor(level))
+}
+
+class RequestLoggingActor(level: Logging.LogLevel) extends Actor with DiagnosticActorLogging {
+  override def mdc(currentMessage: Any): MDC = currentMessage match {
+    case LogMsg(_, metrics) =>
+      metrics
+    case _ =>
+      Logging.emptyMDC
+  }
+
+  override def receive: Receive = {
+    case LogMsg(formattedMsg, _) =>
+      log.log(level, formattedMsg)
+  }
+}

--- a/libats-http/src/main/scala/com/advancedtelematic/libats/http/monitoring/LoggerMetrics.scala
+++ b/libats-http/src/main/scala/com/advancedtelematic/libats/http/monitoring/LoggerMetrics.scala
@@ -8,6 +8,7 @@ import com.codahale.metrics.{Metric, MetricFilter, MetricRegistry}
 import io.circe.Json
 import io.circe.syntax._
 import org.slf4j.{Logger, LoggerFactory}
+
 import scala.collection.JavaConversions._
 import scala.concurrent.Future
 

--- a/libats-logging/README.md
+++ b/libats-logging/README.md
@@ -1,0 +1,47 @@
+# libats logging support
+
+This module provides default settings for logging in libats
+services. Simply include this module in your service and make sure
+your service **does not ** contain any `logback.xml` file in it's
+classpath, or make sure your settings are compatible with the settings
+below.
+
+Logging can be configured through the `LOG_APPENDER` environment variable.
+
+## Stdout Logging
+
+Set the `LOG_APPENDER` environment variable to `stdout`.
+
+## Json Logging
+
+Set the `LOG_APPENDER` environment variable to `json`. Additionally,
+this logging could be overwritten and configued in a `logback.xml`
+using the following settings:
+
+```xml
+<appender name="json" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="com.advancedtelematic.libats.logging.CirceEncoder">
+            <includeContext>false</includeContext>
+            <includeThread>false</includeThread>
+            <includeMdc>false</includeMdc>
+            <includeHttpQuery>false</includeHttpQuery>
+            <prettyPrint>false</prettyPrint>
+            <loggerLength>36</loggerLength>
+        </encoder>
+</appender>
+```
+
+## Async Logging
+
+Both the Stdout logger and Json logger can be used with an async
+logger. Use `LOG_APPENDER=async_stdout` or
+`LOG_APPENDER=async_json`. This is recommended for async services
+avoid blocking when logging.
+
+## Logging Akka-Http Services
+
+You need to include `libats-http` as dependency in your service and
+use the `logResponseMetrics` directive when building the service routes.
+
+All requests will be logged with relevant http metrics, in the case of
+Json logging, this data can also be recorded to MDC.

--- a/libats-logging/src/main/resources/application.conf
+++ b/libats-logging/src/main/resources/application.conf
@@ -1,0 +1,5 @@
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loglevel = "DEBUG"
+  logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
+}

--- a/libats-logging/src/main/resources/logback.xml
+++ b/libats-logging/src/main/resources/logback.xml
@@ -1,0 +1,31 @@
+<configuration>
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%.-1level|%date{ISO8601, UTC}|%logger{36}|%message%n%exception</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="json" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="com.advancedtelematic.libats.logging.CirceEncoder">
+            <includeMdc>false</includeMdc>
+        </encoder>
+    </appender>
+
+    <appender name="async_json" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="json" />
+        <queueSize>512</queueSize>
+    </appender>
+
+    <appender name="async_stdout" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="stdout" />
+        <queueSize>512</queueSize>
+    </appender>
+
+    <logger name="com.zaxxer.hikari" level="info" />
+    <logger name="slick.backend.DatabaseComponent.action" level="info" />
+    <logger name="com.advancedtelematic" level="${ATS_LOG_LEVEL:-INHERITED}" />
+
+    <root level="${rootLevel:-info}">
+        <appender-ref ref="${LOG_APPENDER:-stdout}" />
+    </root>
+</configuration>

--- a/libats-logging/src/main/scala/com/advancedtelematic/libats/logging/CirceEncoder.scala
+++ b/libats-logging/src/main/scala/com/advancedtelematic/libats/logging/CirceEncoder.scala
@@ -1,0 +1,108 @@
+package com.advancedtelematic.libats.logging
+
+import java.time.Instant
+
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.pattern.{TargetLengthBasedClassNameAbbreviator, ThrowableProxyConverter}
+import ch.qos.logback.classic.spi.ILoggingEvent
+import io.circe.{Encoder, Json}
+import io.circe.syntax._
+import io.circe.java8.time._
+
+import scala.collection.JavaConverters._
+
+object CirceLayoutCodecs {
+  implicit val levelEncoder: Encoder[Level] = Encoder.encodeString.contramap(_.toString)
+}
+
+class CirceEncoder extends ch.qos.logback.core.encoder.EncoderBase[ILoggingEvent] {
+  import CirceLayoutCodecs._
+
+  private var includeContext = false
+  private var includeThread = false
+  private var includeMdc = false
+  private var includeHttpQuery = false
+  private var prettyPrint = false
+  private var loggerLength = 36
+
+  private val throwableProxyConverter = new ThrowableProxyConverter
+  private val abbreviator = new TargetLengthBasedClassNameAbbreviator(loggerLength)
+
+  def setLoggerLength(value: Int): Unit = loggerLength = 36
+
+  def setIncludeContext(value: Boolean): Unit = includeContext = value
+
+  def setIncludeThread(value: Boolean): Unit = includeThread = value
+
+  def setPrettyPrint(value: Boolean): Unit = prettyPrint = value
+
+  def setIncludeMdc(value: Boolean): Unit = includeMdc = value
+
+  def setIncludeQuery(value: Boolean): Unit = includeHttpQuery = value
+
+  override def start(): Unit = {
+    throwableProxyConverter.start()
+    super.start()
+  }
+
+  override def stop(): Unit = {
+    throwableProxyConverter.stop()
+    super.stop()
+  }
+
+  override def encode(event: ILoggingEvent): Array[Byte] = {
+    val mdc = event.getMDCPropertyMap.asScala.mapValues(_.asJson)
+
+    val map = Map[String, Json](
+      "at" -> Instant.ofEpochMilli(event.getTimeStamp).asJson,
+      "level" -> event.getLevel.asJson,
+      "logger" -> abbreviator.abbreviate(event.getLoggerName).asJson,
+      "msg" -> event.getFormattedMessage.asJson
+    )
+      .withValue(includeContext, "ctx" -> event.getLoggerContextVO.toString.asJson)
+      .withValue(includeThread, "thread" -> event.getThreadName.asJson)
+      .withValue(includeMdc, "mdc" -> mdc.asJson)
+      .withValue("throwable" -> encodeThrowable(event))
+      .maybeWithValue("http_status", mdc.get("http_status"))
+      .maybeWithValue("http_method", mdc.get("http_method"))
+      .maybeWithValue("http_service_name", mdc.get("http_service_name"))
+      .maybeWithValue("http_stime", mdc.get("http_stime"))
+      .maybeWithValue("http_query", mdc.get("http_query").filter(_ => includeHttpQuery))
+
+    val str = if(prettyPrint) map.asJson.spaces2 else map.asJson.noSpaces
+
+    (str + "\n").getBytes
+  }
+
+  protected def encodeThrowable(value: ILoggingEvent): Json = {
+    val maybeEx = Option(throwableProxyConverter.convert(value)).filter(_ != "")
+    maybeEx.map(_.asJson).getOrElse(Json.Null)
+  }
+
+  override def headerBytes(): Array[Byte] = null
+
+  override def footerBytes(): Array[Byte] = null
+
+  implicit private class MapJsonOps(map: Map[String, Json]) {
+    def maybeWithValue(value: => (String, Option[Json])): Map[String, Json] =
+      value match {
+        case (key, Some(v)) =>
+          map + (key -> v)
+        case _ =>
+          map
+      }
+
+    def withValue(enabled: Boolean, value: => (String, Json)): Map[String, Json] =
+      if(enabled)
+        map + value
+      else
+        map
+
+    def withValue(value: => (String, Json)): Map[String, Json] = value match {
+      case (_, v) if v != Json.Null && v != Json.obj() => map + value
+      case _ => map
+    }
+  }
+}
+


### PR DESCRIPTION
Tested with ota-tuf, pr for tuf follows.

Using a custom Json Logback Encoder as the available encoders (logback-contrib etc) use jackson or some other json library and this way we can just depend on circe. 

Unfortunately I don't know any other way to log the requests with mdc without using this proxy actor. I don't think the risk is big, but it adds that extra layer. I tried a few different approaches like [1], but that doesn't work because akka-http reuses the execution context and also I think it's better to use an extra actor layer than to use an half baked execution context.

[1]: http://yanns.github.io/blog/2014/05/04/slf4j-mapped-diagnostic-context-mdc-with-play-framework/