### PR TITLE
Use always offset first and limit second as parameters.

### DIFF
--- a/libats/src/main/scala/com/advancedtelematic/libats/data/PaginationResult.scala
+++ b/libats/src/main/scala/com/advancedtelematic/libats/data/PaginationResult.scala
@@ -1,6 +1,6 @@
 package com.advancedtelematic.libats.data
 
-final case class PaginationResult[A](total: Long, limit: Long, offset: Long, values: Seq[A]) {
+final case class PaginationResult[A](values: Seq[A], total: Long, offset: Long, limit: Long) {
   def map[B](f: A => B): PaginationResult[B] = this.copy(values = values.map(f))
 }
 


### PR DESCRIPTION
When paginating DB results, it would be nice to use `offset` and `limit` consistently. Otherwise it's easy to mix them up and introduce some silly bug. We're always using `offset` first and `limit` second, except in class `PaginationResult`. This PR addresses that.

Also, since just swapping `offset` and `limit` would still compile but break all the services that use pagination without named parameters, I made sure to change the position of the `values` parameter as well. So all services that use this `PaginationResult` will need to update after bumping up libats, but will not break silently.