### PR TITLE
Add CampaignUpdateEvent,DeviceUpdateEvent

### DIFF
--- a/libats-messaging-datatype/src/main/scala/com/advancedtelematic/libats/messaging_datatype/DataType.scala
+++ b/libats-messaging-datatype/src/main/scala/com/advancedtelematic/libats/messaging_datatype/DataType.scala
@@ -81,4 +81,16 @@ object DataType {
                          deviceTime: Instant,
                          receivedAt: Instant,
                          payload: Json)
+
+  object CampaignUpdateStatus extends Enumeration {
+    type CampaignUpdateStatus = Value
+
+    val Activated, Available, Accepted, Canceling = Value
+  }
+
+  object DeviceUpdateStatus extends Enumeration {
+    type DeviceUpdateStatus = Value
+
+    val Available, InFlight, Canceled, Failed, Finished = Value
+  }
 }

--- a/libats-messaging-datatype/src/main/scala/com/advancedtelematic/libats/messaging_datatype/Messages.scala
+++ b/libats-messaging-datatype/src/main/scala/com/advancedtelematic/libats/messaging_datatype/Messages.scala
@@ -8,9 +8,11 @@ import java.util.UUID
 import cats.syntax.either._
 import com.advancedtelematic.libats.data.DataType.{Checksum, CorrelationId, Namespace}
 import com.advancedtelematic.libats.data.RefinedUtils._
+import com.advancedtelematic.libats.messaging_datatype.DataType.DeviceUpdateStatus.DeviceUpdateStatus
+import com.advancedtelematic.libats.messaging_datatype.DataType.CampaignUpdateStatus.CampaignUpdateStatus
 import com.advancedtelematic.libats.messaging_datatype.DataType.UpdateType.UpdateType
 import com.advancedtelematic.libats.messaging_datatype.DataType._
-import com.advancedtelematic.libats.messaging_datatype.Messages.{BsDiffGenerationFailed, BsDiffRequest, CampaignLaunched, DeltaGenerationFailed, DeltaRequest, DeviceEventMessage, DeviceUpdateReport, GeneratedBsDiff, GeneratedDelta, UserCreated}
+import com.advancedtelematic.libats.messaging_datatype.Messages.{BsDiffGenerationFailed, BsDiffRequest, CampaignLaunched, DeltaGenerationFailed, DeltaRequest, CampaignUpdateEvent, DeviceEventMessage, DeviceUpdateEvent, DeviceUpdateReport, GeneratedBsDiff, GeneratedDelta, UserCreated}
 import com.advancedtelematic.libats.messaging_datatype.Messages.DeviceInstallationReport
 import io.circe._
 import io.circe.generic.semiauto._
@@ -35,6 +37,18 @@ object MessageCodecs {
       ns    <- c.get[String]("namespace").map(Namespace.apply)
     } yield DeviceEventMessage(ns, event)
   }
+
+  implicit val deviceUpdateStatusEncoder: Encoder[DeviceUpdateStatus] = Encoder.enumEncoder(DeviceUpdateStatus)
+  implicit val deviceUpdateStatusDecoder: Decoder[DeviceUpdateStatus] = Decoder.enumDecoder(DeviceUpdateStatus)
+
+  implicit val deviceUpdateEventEncoder: Encoder[DeviceUpdateEvent] = deriveEncoder[DeviceUpdateEvent]
+  implicit val deviceUpdateEventDecoder: Decoder[DeviceUpdateEvent] = deriveDecoder[DeviceUpdateEvent]
+
+  implicit val campaignUpdateStatusEncoder: Encoder[CampaignUpdateStatus] = Encoder.enumEncoder(CampaignUpdateStatus)
+  implicit val campaignUpdateStatusDecoder: Decoder[CampaignUpdateStatus] = Decoder.enumDecoder(CampaignUpdateStatus)
+
+  implicit val campaignUpdateEventEncoder: Encoder[CampaignUpdateEvent] = deriveEncoder[CampaignUpdateEvent]
+  implicit val campaignUpdateEventDecoder: Decoder[CampaignUpdateEvent] = deriveDecoder[CampaignUpdateEvent]
 
   implicit val userCreatedEncoder: Encoder[UserCreated] = deriveEncoder
   implicit val userCreatedDecoder: Decoder[UserCreated] = deriveDecoder
@@ -140,6 +154,19 @@ object Messages {
 
   case class ImageStorageUsage(namespace: Namespace, timestamp: Instant, byteCount: Long)
 
+  final case class DeviceUpdateEvent(namespace: Namespace,
+                                     eventTime: Instant,
+                                     updateStatus: DeviceUpdateStatus,
+                                     correlationId: CorrelationId,
+                                     deviceUuid: DeviceId)
+
+  final case class CampaignUpdateEvent(namespace: Namespace,
+                                       eventTime: Instant,
+                                       updateStatus: CampaignUpdateStatus,
+                                       campaignId: CorrelationId,
+                                       sourceUpdateId: CorrelationId,
+                                       deviceUuids: Seq[DeviceId])
+
   @deprecated("use data type from libtuf_server", "v0.1.1-21")
   case class DeviceUpdateReport(namespace: Namespace, device: DeviceId, updateId: UpdateId, timestampVersion: Int,
                                 operationResult: Map[EcuSerial, OperationResult], resultCode: Int)
@@ -176,6 +203,10 @@ object Messages {
   implicit val treeHubCommitMessageLike = MessageLike.derive[TreehubCommit](_.commit.value)
 
   implicit val deviceEventMessageType = MessageLike[DeviceEventMessage](_.namespace.get)
+
+  implicit val deviceUpdateEventType = MessageLike[DeviceUpdateEvent](_.namespace.get)
+
+  implicit val campaignUpdateEventType = MessageLike[CampaignUpdateEvent](_.namespace.get)
 
   @deprecated("use data type from libtuf_server", "v0.1.1-21")
   implicit val deviceUpdateReportMessageLike = MessageLike[DeviceUpdateReport](_.device.toString)


### PR DESCRIPTION
`DeviceUpdateEvent` replaces legacy `UpdateSpec`.
`CampaignUpdateEvent` may replace campaigner-director API.