### PR TITLE
Turn library logback.xml into base config to include in service

### DIFF
--- a/libats-logging/README.md
+++ b/libats-logging/README.md
@@ -1,10 +1,17 @@
 # libats logging support
 
 This module provides default settings for logging in libats
-services. Simply include this module in your service and make sure
-your service **does not ** contain any `logback.xml` file in it's
-classpath, or make sure your settings are compatible with the settings
-below.
+services. Simply include this module in your service. It comes with a configuration file
+called `logback-base.xml` which you can include in your service's logback.xml like this:
+
+```xml
+<configuration>
+    <include resource="logback-libats.xml"/>
+</configuration>
+```
+
+You can also extend it to a `logback.xml` file after changing the top-level `<included>` element
+to `<configuration>`.
 
 Logging can be configured through the `LOG_APPENDER` environment variable.
 

--- a/libats-logging/src/main/resources/logback-libats.xml
+++ b/libats-logging/src/main/resources/logback-libats.xml
@@ -1,4 +1,4 @@
-<configuration>
+<included>
     <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%.-1level|%date{ISO8601, UTC}|%logger{36}|%message%n%exception</pattern>
@@ -28,4 +28,4 @@
     <root level="${ROOT_LOG_LEVEL:-info}">
         <appender-ref ref="${LOG_APPENDER:-stdout}" />
     </root>
-</configuration>
+</included>


### PR DESCRIPTION
A logback.xml file shouldn't be put into a library since it can't be
extended and it's hard to control which of multiple such files get
loaded from the classpath.