### PR TITLE
Create ResultCode and FailureCode types for type safety

### DIFF
--- a/libats/src/main/scala/com/advancedtelematic/libats/data/DataType.scala
+++ b/libats/src/main/scala/com/advancedtelematic/libats/data/DataType.scala
@@ -9,6 +9,10 @@ import io.circe.{Decoder, Encoder}
 import scala.language.postfixOps
 
 object DataType {
+
+  type ResultCode = String
+  type FailureCode <: ResultCode
+
   final case class Namespace(get: String) extends AnyVal
 
   case class Checksum(method: HashMethod, hash: Refined[String, ValidChecksum])

--- a/libats/src/main/scala/com/advancedtelematic/libats/data/DataType.scala
+++ b/libats/src/main/scala/com/advancedtelematic/libats/data/DataType.scala
@@ -10,8 +10,7 @@ import scala.language.postfixOps
 
 object DataType {
 
-  type ResultCode = String
-  type FailureCode <: ResultCode
+  final case class ResultCode(value: String) extends AnyVal
 
   final case class Namespace(get: String) extends AnyVal
 


### PR DESCRIPTION
We're starting to use quite a bit result codes and failure codes as `String`, specially in campaigner and device-registry. I thought it would be nice to have some type safety by introducing these types.