### PR TITLE
[OTA-2308] Move DeviceOemId from device-registry

### DIFF
--- a/libats/src/main/scala/com/advancedtelematic/libats/data/DataType.scala
+++ b/libats/src/main/scala/com/advancedtelematic/libats/data/DataType.scala
@@ -14,6 +14,8 @@ object DataType {
 
   final case class Namespace(get: String) extends AnyVal
 
+  final case class DeviceOemId(value: String) extends AnyVal
+
   case class Checksum(method: HashMethod, hash: Refined[String, ValidChecksum])
 
   object HashMethod extends Enumeration {


### PR DESCRIPTION
We are going to use `DeviceOemId` in campaigner for the CSV export. We might as well move it to libats.