### PR TITLE
Don't expose DeviceOemId as a class to other services

### DIFF
--- a/libats/src/main/scala/com/advancedtelematic/libats/data/DataType.scala
+++ b/libats/src/main/scala/com/advancedtelematic/libats/data/DataType.scala
@@ -14,8 +14,6 @@ object DataType {
 
   final case class Namespace(get: String) extends AnyVal
 
-  final case class DeviceOemId(value: String) extends AnyVal
-
   case class Checksum(method: HashMethod, hash: Refined[String, ValidChecksum])
 
   object HashMethod extends Enumeration {


### PR DESCRIPTION
We decided this class should keep on living in device-registry after all, so let's remove it from here.