### PR TITLE
Use ResultCode in InstallationResult for type safety

### DIFF
--- a/libats-messaging-datatype/src/main/scala/com/advancedtelematic/libats/messaging_datatype/DataType.scala
+++ b/libats-messaging-datatype/src/main/scala/com/advancedtelematic/libats/messaging_datatype/DataType.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 import java.util.UUID
 
 import com.advancedtelematic.libats.data.DataType.HashMethod.HashMethod
-import com.advancedtelematic.libats.data.DataType.ValidChecksum
+import com.advancedtelematic.libats.data.DataType.{ResultCode, ResultDescription, ValidChecksum}
 import com.advancedtelematic.libats.data.UUIDKey.{UUIDKey, UUIDKeyObj}
 import eu.timepit.refined.api.{Refined, Validate}
 import io.circe.Json
@@ -63,7 +63,7 @@ object DataType {
     def isSuccess:Boolean = resultCode == 0 || resultCode == 1
   }
 
-  final case class InstallationResult(success: Boolean, code: String, description: String)
+  final case class InstallationResult(success: Boolean, code: ResultCode, description: ResultDescription)
 
   final case class EcuInstallationReport(result: InstallationResult, target: Seq[String], rawReport: Option[Array[Byte]] = None)
 

--- a/libats/src/main/scala/com/advancedtelematic/libats/data/DataType.scala
+++ b/libats/src/main/scala/com/advancedtelematic/libats/data/DataType.scala
@@ -10,9 +10,10 @@ import scala.language.postfixOps
 
 object DataType {
 
-  final case class ResultCode(value: String) extends AnyVal
-
   final case class Namespace(get: String) extends AnyVal
+
+  final case class ResultCode(value: String) extends AnyVal
+  final case class ResultDescription(value: String) extends AnyVal
 
   case class Checksum(method: HashMethod, hash: Refined[String, ValidChecksum])
 


### PR DESCRIPTION
Let's use this `ResultCode` and `ResultDescription` value classes in the `InstallationResult` to gain some type safety and readability? See #97.