### PR TITLE
Bump Akka and AkkaHttp to the latest version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 val Library = new {
   object Version {
-    val akka = "2.5.20"
-    val akkaHttp = "10.1.7"
-    val akkaHttpCirce = "1.25.2"
+    val akka = "2.5.23"
+    val akkaHttp = "10.1.8"
+    val akkaHttpCirce = "1.27.0"
     val circe = "0.11.1"
     val refined = "0.8.7"
     val scalaTest = "3.0.5"

--- a/libats-metrics-akka/src/main/scala/com/advancedtelematic/metrics/AkkaHttpMetricsSink.scala
+++ b/libats-metrics-akka/src/main/scala/com/advancedtelematic/metrics/AkkaHttpMetricsSink.scala
@@ -7,11 +7,9 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri.{Path, Query}
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{Authorization, BasicHttpCredentials}
-import akka.http.scaladsl.server.Directive0
 import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Flow, Sink}
-import com.codahale.metrics.MetricRegistry
 
 import scala.util.{Failure, Success}
 
@@ -32,7 +30,7 @@ object AkkaHttpMetricsSink {
         Post(
           requestUri,
           HttpEntity(
-            MediaTypes.`application/x-www-form-urlencoded` withCharset HttpCharsets.`UTF-8`,
+            MediaTypes.`application/x-www-form-urlencoded`,
             metrics
           )
         )


### PR DESCRIPTION
One particular endpoint in device-registry is failing for me, apparently because the Akka version in libats is older than the one in device-registry. This fixes that, though we might have to update the Akka version in other services.