### PR TITLE
Add main class to run migrations

### DIFF
--- a/libats-slick/README.adoc
+++ b/libats-slick/README.adoc
@@ -62,19 +62,14 @@ When using BootMigrations, both SQL and Scala migrations are executed
 synchronously.
 
 This means the app will not respond to `HTTP GET /health` until the
-migrations are executed, which can take more time than marathon is
+migrations are executed, which can take more time than kubernetes is
 configured to wait. This means that to run the migration you might
-need to adjust the marathon timeout for your current deployment and
+need to adjust the liveness timeout for your current deployment and
 adjust it back after running the migration.
 
-If your service is capable of supporting asynchronous migrations, you
-can instead mixin `AsyncMigrations` You will need to call the
-`migrate` method, which returns a future on which you need to await
-after you bind the service http handler. See
-https://github.com/advancedtelematic/libats/blob/master/libats-slick/src/main/scala/com/advancedtelematic/libats/slick/db/BootMigrations.scala[BootMigrations.scala]
-
-Alternatively, you can set `ASYNC_MIGRATE=true` and this will cause
-migrations to run in the background.
+You can instead set `ASYNC_MIGRATE=true` and this will cause
+migrations to run in the background while the server starts and
+continues serving requests.
 
 === App level migrations
 

--- a/libats-slick/src/main/scala/com/advancedtelematic/libats/test/DatabaseSpec.scala
+++ b/libats-slick/src/main/scala/com/advancedtelematic/libats/test/DatabaseSpec.scala
@@ -31,13 +31,17 @@ trait DatabaseSpec extends BeforeAndAfterAll {
 
   private lazy val testDbConfig: Config = config.getConfig("database")
 
-  private lazy val slickDbConfig: Config = {
+  private [libats] lazy val slickDbConfig: Config = {
     val withSchemaName =
       ConfigFactory.parseMap(Map("catalog" -> schemaName.toLowerCase).asJava)
     withSchemaName.withFallback(testDbConfig)
   }
 
-  private def resetDatabase() = {
+  protected [libats] def cleanDatabase(): Unit = {
+    flyway.clean()
+  }
+
+  private lazy val flyway = {
     val url = slickDbConfig.getString("url")
     val user = slickDbConfig.getConfig("properties").getString("user")
     val password = slickDbConfig.getConfig("properties").getString("password")
@@ -48,6 +52,10 @@ trait DatabaseSpec extends BeforeAndAfterAll {
     flyway.setDataSource(url, user, password)
     flyway.setSchemas(schemaName)
     flyway.setLocations("classpath:db.migration")
+    flyway
+  }
+
+  private def resetDatabase() = {
     flyway.clean()
     flyway.migrate()
   }

--- a/libats-slick/src/test/resources/logback-test.xml
+++ b/libats-slick/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%.-1level|%date{ISO8601, UTC}|%logger{36}|%message%n%exception</pattern>
+        </encoder>
+    </appender>
+
+    <root level="${ROOT_LOG_LEVEL:-info}">
+        <appender-ref ref="stdout" />
+    </root>
+</configuration>

--- a/libats-slick/src/test/resources/logback.xml
+++ b/libats-slick/src/test/resources/logback.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-    <logger name="scala.slick" level="INFO" />
-</configuration>

--- a/libats-slick/src/test/scala/com/advancedtelematic/libats/slick/db/RunMigrationsSpec.scala
+++ b/libats-slick/src/test/scala/com/advancedtelematic/libats/slick/db/RunMigrationsSpec.scala
@@ -1,0 +1,21 @@
+package com.advancedtelematic.libats.slick.db
+
+import com.advancedtelematic.libats.test.DatabaseSpec
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Seconds, Span}
+import org.scalatest.{FunSuite, Matchers}
+import slick.jdbc.MySQLProfile.api._
+
+class RunMigrationsSpec extends FunSuite with Matchers with ScalaFutures with DatabaseSpec {
+
+  override implicit def patienceConfig = PatienceConfig().copy(timeout = Span(5, Seconds))
+
+  test("runs migrations") {
+    cleanDatabase()
+
+    RunMigrations(slickDbConfig.atKey("database")).get shouldBe 1
+
+    val sql = sql"select count(*) from schema_version".as[Int]
+    db.run(sql).futureValue.head shouldBe > (1)
+  }
+}


### PR DESCRIPTION
Remove `AsyncMigrations`. This is not used by any project and can
anyway be used with `ASYNC_MIGRATE=true` instead.