### PR TITLE
Add trait that forces an app to quit if schema has pending migrations

### DIFF
--- a/libats-slick/src/main/resources/reference.conf
+++ b/libats-slick/src/main/resources/reference.conf
@@ -1,5 +1,7 @@
 ats {
   database {
+    skip_migration_check = false
+    skip_migration_check = ${?SKIP_MIGRATION_CHECK}
     asyncMigrations = false
     asyncMigrations = ${?ASYNC_MIGRATE}
     encryption {

--- a/libats-slick/src/test/scala/com/advancedtelematic/libats/slick/db/RunMigrationsSpec.scala
+++ b/libats-slick/src/test/scala/com/advancedtelematic/libats/slick/db/RunMigrationsSpec.scala
@@ -10,12 +10,25 @@ class RunMigrationsSpec extends FunSuite with Matchers with ScalaFutures with Da
 
   override implicit def patienceConfig = PatienceConfig().copy(timeout = Span(5, Seconds))
 
+  lazy val flywayConfig = slickDbConfig.atKey("database")
+
   test("runs migrations") {
     cleanDatabase()
 
-    RunMigrations(slickDbConfig.atKey("database")).get shouldBe 1
+    RunMigrations(flywayConfig).get shouldBe 1
 
     val sql = sql"select count(*) from schema_version".as[Int]
     db.run(sql).futureValue.head shouldBe > (1)
+  }
+
+  test("reports pending migrations") {
+    cleanDatabase()
+    RunMigrations.schemaIsCompatible(flywayConfig).get shouldBe false
+  }
+
+  test("runs without pending migrations") {
+    cleanDatabase()
+    RunMigrations(flywayConfig).get shouldBe 1
+    RunMigrations.schemaIsCompatible(flywayConfig).get shouldBe true
   }
 }


### PR DESCRIPTION
I think this is all we need for OTA-3457:

  - The older version will not detect pending migrations, these are
    calculated from source, so the old version would continue running.

  - The new version deployment would fail as flyway would detect
    pending migrations