### PR TITLE
[OTA-3845] Upgrade Kafka clients

### DIFF
--- a/libats-messaging/build.sbt
+++ b/libats-messaging/build.sbt
@@ -1,3 +1,3 @@
 name := "libats-messaging"
 
-libraryDependencies += "com.typesafe.akka" %% "akka-stream-kafka" % "0.19"
+libraryDependencies += "com.typesafe.akka" %% "akka-stream-kafka" % "1.0.4"

--- a/libats-messaging/src/main/scala/com/advancedtelematic/libats/messaging/kafka/KafkaClient.scala
+++ b/libats-messaging/src/main/scala/com/advancedtelematic/libats/messaging/kafka/KafkaClient.scala
@@ -7,7 +7,7 @@ package com.advancedtelematic.libats.messaging.kafka
 
 import java.util.concurrent.TimeUnit
 
-import akka.{NotUsed, event}
+import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.event.Logging
 import akka.kafka.ConsumerMessage.CommittableOffsetBatch
@@ -125,7 +125,8 @@ object KafkaClient {
 
   private[this] def producer(config: Config)
                             (implicit system: ActorSystem): KafkaProducer[Array[Byte], String] =
-    ProducerSettings(system, new ByteArraySerializer, new StringSerializer)
-      .withBootstrapServers(config.getString("host"))
-      .createKafkaProducer()
+    ProducerSettings.createKafkaProducer(
+      ProducerSettings(system, new ByteArraySerializer, new StringSerializer)
+        .withBootstrapServers(config.getString("host"))
+    )
 }

--- a/libats-metrics-kafka/build.sbt
+++ b/libats-metrics-kafka/build.sbt
@@ -1,3 +1,3 @@
 name := "libats-metrics-kafka"
 
-libraryDependencies += "org.apache.kafka" % "kafka-clients" % "0.10.2.0" % "provided"
+libraryDependencies += "org.apache.kafka" % "kafka-clients" % "2.1.1" % Provided


### PR DESCRIPTION
Since Kafka 0.10.0.1 we can upgrade the clients without updating the brokers. See https://docs.confluent.io/current/installation/upgrade.html and other links in OTA-3845.