### PR TITLE
Make the Flyway schema table configurable.

### DIFF
--- a/libats-slick/src/main/resources/reference.conf
+++ b/libats-slick/src/main/resources/reference.conf
@@ -10,5 +10,7 @@ ats {
       password = ""
       password = ${?DB_ENCRYPTION_PASSWORD}
     }
+    schema-table = "schema_version"
+    schema-table = ${?DB_SCHEMA_TABLE}
   }
 }

--- a/libats-slick/src/main/scala/com/advancedtelematic/libats/slick/db/BootMigrations.scala
+++ b/libats-slick/src/main/scala/com/advancedtelematic/libats/slick/db/BootMigrations.scala
@@ -45,8 +45,13 @@ protected [db] object RunMigrations {
     val user = config.getString("database.properties.user")
     val password = config.getString("database.properties.password")
     val schemaO = Either.catchOnly[ConfigException.Missing](config.getString("database.catalog")).toOption
+    val schemaTable = Either.catchOnly[ConfigException.Missing](
+      config.getString("database.schema-table")
+    ).toOption.getOrElse(
+      ConfigFactory.load().getString("ats.database.schema-table")
+    )
 
-    val flywayConfig = Flyway.configure().dataSource(url, user, password)
+    val flywayConfig = Flyway.configure().dataSource(url, user, password).table(schemaTable)
     schemaO.fold(flywayConfig)(s => flywayConfig.schemas(s)).load()
   }
 }

--- a/libats-slick/src/test/scala/com/advancedtelematic/libats/slick/db/RunMigrationsSpec.scala
+++ b/libats-slick/src/test/scala/com/advancedtelematic/libats/slick/db/RunMigrationsSpec.scala
@@ -17,7 +17,7 @@ class RunMigrationsSpec extends FunSuite with Matchers with ScalaFutures with Da
 
     RunMigrations(flywayConfig).get shouldBe 1
 
-    val sql = sql"select count(*) from flyway_schema_history".as[Int]
+    val sql = sql"select count(*) from schema_version".as[Int]
     db.run(sql).futureValue.head shouldBe > (1)
   }
 


### PR DESCRIPTION
Up until version 5.0.0 Flyway used to store the migration historical info in a table called `schema_version`. From version 5 the table is called `flyway_schema_history`. Version 6 drops the fallback mechanism that allowed to still user the old name for the table. We want to migrate from 4 to 6 but don't want to go through the hassle of renaming the old schema table.

Related:
  - https://github.com/flyway/flyway/issues/2010
  - https://flywaydb.org/documentation/releaseNotes#5.0.0