### PR TITLE
Use static val for prometheus counters

### DIFF
--- a/libats-messaging/src/main/scala/com/advancedtelematic/libats/messaging/daemon/MessageBusListenerActor.scala
+++ b/libats-messaging/src/main/scala/com/advancedtelematic/libats/messaging/daemon/MessageBusListenerActor.scala
@@ -36,11 +36,11 @@ class MessageBusListenerActor[M](source: Source[M, NotUsed], monitor: ListenerMo
         log.warning("Listener already subscribed. Ignoring Subscribe message")
       case Failure(ex) =>
         log.error(ex, "Source/Listener died, subscribing again")
-        monitor.onError(ex)
+        Try(monitor.onError(ex))
         trySubscribeDelayed()
         context become idle
       case Done =>
-        monitor.onFinished
+        Try(monitor.onFinished)
         log.info("Source finished, stopping message listener actor")
         context.stop(self)
     }

--- a/libats-messaging/src/main/scala/com/advancedtelematic/libats/messaging/daemon/MessageBusListenerActor.scala
+++ b/libats-messaging/src/main/scala/com/advancedtelematic/libats/messaging/daemon/MessageBusListenerActor.scala
@@ -55,7 +55,7 @@ class MessageBusListenerActor[M](source: Source[M, NotUsed], monitor: ListenerMo
   }
 
   private def monitorSafe: M => Future[M] = { msg =>
-    monitor.onProcessed.map(_ => msg).recover {
+    Future.fromTry(Try(monitor.onProcessed)).flatten.map(_ => msg).recover {
       case tx =>
         log.warning(s"Could not monitor onProcessed state: ${tx.getMessage}")
         msg

--- a/libats-metrics-kafka/src/main/scala/com/advancedtelematic/metrics/MonitoredBusListenerSupport.scala
+++ b/libats-metrics-kafka/src/main/scala/com/advancedtelematic/metrics/MonitoredBusListenerSupport.scala
@@ -12,6 +12,6 @@ trait MonitoredBusListenerSupport {
 
   def startMonitoredListener[T : MessageLike](op: MsgOperation[T], registry: CollectorRegistry = CollectorRegistry.defaultRegistry,
                                               skipProcessingErrors: Boolean = false): ActorRef = {
-    startListener(op, PrometheusMessagingMonitor[T](registry), skipProcessingErrors)
+    startListener(op, PrometheusMessagingMonitor[T](), skipProcessingErrors)
   }
 }

--- a/libats-metrics-kafka/src/main/scala/com/advancedtelematic/metrics/PrometheusMessagingMonitor.scala
+++ b/libats-metrics-kafka/src/main/scala/com/advancedtelematic/metrics/PrometheusMessagingMonitor.scala
@@ -8,29 +8,32 @@ import io.prometheus.client.{CollectorRegistry, Counter}
 import scala.concurrent.Future
 
 object PrometheusMessagingMonitor {
-  def apply[T : MessageLike](registry: CollectorRegistry = CollectorRegistry.defaultRegistry) =
-    new PrometheusMessagingMonitor(registry, implicitly[MessageLike[T]].streamName)
-}
-
-class PrometheusMessagingMonitor(registry: CollectorRegistry, streamName: String) extends ListenerMonitor {
-  private lazy val processed =
+  protected lazy val processed =
     Counter.build().name("bus_listener_processed")
       .help("bus listener processed")
       .labelNames("stream_name")
-      .create().register[Counter](registry)
+      .create().register[Counter]()
 
-  private lazy val error =
+  protected lazy val error =
     Counter.build().name("bus_listener_error")
       .help("bus listener error")
       .labelNames("stream_name")
-      .create().register[Counter](registry)
+      .create().register[Counter]()
 
-  private lazy val restarts =
+  protected lazy val restarts =
     Counter.build()
       .name("bus_listener_restarts")
       .help("bus listener restarts")
       .labelNames("stream_name")
-      .create().register[Counter](registry)
+      .create().register[Counter]()
+
+
+  def apply[T : MessageLike]() =
+    new PrometheusMessagingMonitor(implicitly[MessageLike[T]].streamName)
+}
+
+class PrometheusMessagingMonitor(streamName: String) extends ListenerMonitor {
+  import PrometheusMessagingMonitor._
 
   override def onProcessed: Future[Unit] = FastFuture.successful(processed.labels(streamName).inc())
 


### PR DESCRIPTION
prometheus java client requires us to use a static val to share counters.

See https://github.com/prometheus/client_java#registering-metrics

Fix bug when failure that causes subscriber to die

even when `monitorSafe` is used.

This is a rather subtle and hard to track bug.

`monitor.onProcessed` returns a future and `monitorSafe` recovers from
that future. The problem is `monitor.onProcessed` can fail **before**
actually creating the future, so `monitorOnProcessed` will fail before
it returns a future that `monitorSafe` can recover from, so this was
not safe at all.

Changed it to wrap `onProcessed` into a try to really make sure the
listener does not die if something goes wrong with `monitor`.