### PR TITLE
Catch exceptions when MsgOperation fails to create a future

### DIFF
--- a/libats-messaging/src/main/scala/com/advancedtelematic/libats/messaging/MessageListener.scala
+++ b/libats-messaging/src/main/scala/com/advancedtelematic/libats/messaging/MessageListener.scala
@@ -1,7 +1,5 @@
 package com.advancedtelematic.libats.messaging
 
-import java.rmi.registry.Registry
-
 import akka.Done
 import akka.actor.{ActorSystem, Props}
 import akka.event.LoggingAdapter
@@ -9,27 +7,39 @@ import akka.http.scaladsl.util.FastFuture
 import com.advancedtelematic.libats.messaging.MsgOperation.MsgOperation
 import com.advancedtelematic.libats.messaging.daemon.MessageBusListenerActor
 import com.advancedtelematic.libats.messaging_datatype.MessageLike
-import com.codahale.metrics.MetricRegistry
 import com.typesafe.config.Config
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
 
 
 object MsgOperation {
   type MsgOperation[T] = T => Future[_]
 
   def logFailed[T](fn: MsgOperation[T])(implicit log: LoggingAdapter, ec: ExecutionContext): MsgOperation[T] = (msg: T) => {
-    fn(msg).recoverWith {
-      case ex =>
-        log.error(ex, s"[Fatal] Could not process message $msg")
+    try {
+      fn(msg).recoverWith {
+        case ex =>
+          log.error(ex, s"[Fatal] MsgOperation returned a failed future:  $msg")
+          FastFuture.failed(ex)
+      }
+    } catch {
+      case NonFatal(ex) =>
+        log.error(ex, s"[NonFatal] MsgOperation could not return a valid future: $msg")
         FastFuture.failed(ex)
     }
   }
 
   def recoverFailed[T](fn: MsgOperation[T])(implicit log: LoggingAdapter, ec: ExecutionContext): MsgOperation[T] = (msg: T) => {
-    fn(msg).recoverWith {
-      case ex =>
-        log.error(ex, s"[NonFatal] Could not process message $msg")
+    try {
+      fn(msg).recoverWith {
+        case ex =>
+          log.error(ex, s"[NonFatal] MsgOperation returned a failed future:  $msg")
+          Future.successful(Done)
+      }
+    } catch {
+      case NonFatal(ex) =>
+        log.error(ex, s"[NonFatal] MsgOperation could not return a valid future: $msg")
         Future.successful(Done)
     }
   }

--- a/libats/src/main/scala/com/advancedtelematic/libats/data/UUIDKey.scala
+++ b/libats/src/main/scala/com/advancedtelematic/libats/data/UUIDKey.scala
@@ -21,10 +21,10 @@ object UUIDKey {
     implicit val encoder: Encoder[Self] = Encoder[String].contramap(_.uuid.toString)
 
     implicit def decoder(implicit gen: SelfGen): Decoder[Self] =
-      Decoder[String].map(s => fromJava(UUID.fromString(s)))
+      Decoder[UUID].map(fromJava)
 
     implicit def keyDecoder(implicit gen: SelfGen): KeyDecoder[Self] =
-      KeyDecoder[String].map(s => gen.from(UUID.fromString(s) :: HNil))
+      KeyDecoder[UUID].map { uuid => gen.from(uuid :: HNil) }
 
     implicit def keyEncoder: KeyEncoder[Self] = KeyEncoder[String].contramap(_.uuid.toString)
 


### PR DESCRIPTION
We currently catch a failed future when MsgOperation returns a failed
future, but if MsgOperation cannot create a valid future, successful or
failed, we don't catch that and propagate the exception up.

This change catches exceptions when MsgOperation fails before it can
produce a valid future.

Fix decoding errors when decoding UUID

If `String` is not a valid UUID the decoders would throw an
`IllegalArgumentException` rather than a failed decoder. This makes UUIDKey
decoders use the default circe decoders for UUID which handle those
exceptions.