### PR TITLE
Error representation for DecodingFailure should include history

### DIFF
--- a/libats-http/src/main/scala/com/advancedtelematic/libats/http/ErrorHandler.scala
+++ b/libats-http/src/main/scala/com/advancedtelematic/libats/http/ErrorHandler.scala
@@ -72,9 +72,9 @@ object Errors {
       statusCode -> ErrorRepresentation(code, desc, None, uuid.some)
   }
 
-  private val onDecodingError: PF = {
-    case DecodingFailure(msg, _) =>
-      StatusCodes.BadRequest -> ErrorRepresentation(ErrorCodes.InvalidEntity, msg)
+  private[http] val onDecodingError: PF = {
+    case df: DecodingFailure =>
+      StatusCodes.BadRequest -> ErrorRepresentation(ErrorCodes.InvalidEntity, df.getMessage())
   }
 
   private val onJsonError: PF = {

--- a/libats-http/src/test/scala/com/advancedtelematic/libats/http/ErrorHandlerSpec.scala
+++ b/libats-http/src/test/scala/com/advancedtelematic/libats/http/ErrorHandlerSpec.scala
@@ -1,0 +1,14 @@
+package com.advancedtelematic.libats.http
+
+import io.circe.CursorOp.DownField
+import io.circe.DecodingFailure
+import org.scalatest.FunSuite
+
+class ErrorHandlerSpec extends FunSuite {
+
+  test("DecodingFailure error handler keeps decoding history") {
+    val (_, errorRepresentation) = Errors.onDecodingError(DecodingFailure("msg", List(DownField("field"))))
+    assert(errorRepresentation.description == "msg: DownField(field)")
+  }
+
+}


### PR DESCRIPTION
Currently the ErrorRepresentation only includes the message like
"Attempt to decode value on failed cursor", now it includes also the
history which led to the operation that failed.