### PR TITLE
Add `after` and `before` for `java.time.Instant` in scalatest

### DIFF
--- a/libats-slick/src/main/scala/com/advancedtelematic/libats/test/InstantMatchers.scala
+++ b/libats-slick/src/main/scala/com/advancedtelematic/libats/test/InstantMatchers.scala
@@ -1,0 +1,17 @@
+package com.advancedtelematic.libats.test
+
+import java.time.Instant
+
+import org.scalatest.matchers.{BeMatcher, MatchResult}
+
+trait InstantMatchers {
+  def after(other: Instant): BeMatcher[Instant] = (me: Instant) => MatchResult(me.isAfter(other),
+    me + " was not after " + other,
+    me + " was after " + other)
+
+  def before(other: Instant): BeMatcher[Instant] = (me: Instant) => MatchResult(me.isBefore(other),
+    me + " was not before " + other,
+    me + " was before " + other)
+}
+
+object InstantMatchers extends InstantMatchers

--- a/libats-slick/src/test/scala/com/advancedtelematic/libats/slick/db/InstantMatchersSpec.scala
+++ b/libats-slick/src/test/scala/com/advancedtelematic/libats/slick/db/InstantMatchersSpec.scala
@@ -1,0 +1,16 @@
+package com.advancedtelematic.libats.slick.db
+
+import java.time.Instant
+
+import com.advancedtelematic.libats.test.InstantMatchers
+import org.scalatest.{FunSuite, Matchers}
+
+class InstantMatchersSpec extends FunSuite with Matchers with InstantMatchers {
+   test("be before") {
+     Instant.now() shouldBe before(Instant.now().plusSeconds(30))
+   }
+
+  test("be after") {
+    Instant.now() shouldBe after(Instant.now().minusSeconds(30))
+  }
+}


### PR DESCRIPTION
Enables syntax like `ts0 is after(ts1)`

Adding this to `libats-slick` because this is the only package that already has a class that is used in tests in downstream projects (`DatabaseSpec`) and I don't think this warrants a separate module