### PR TITLE
Default rejection handler: show the JSON decoding history (path)

### DIFF
--- a/libats-http/src/main/scala/com/advancedtelematic/libats/http/DefaultRejectionHandler.scala
+++ b/libats-http/src/main/scala/com/advancedtelematic/libats/http/DefaultRejectionHandler.scala
@@ -31,10 +31,10 @@ object DefaultRejectionHandler {
     case MalformedRequestContentRejection(_, DeserializationException(RefinementError(_, msg))) =>
       complete(StatusCodes.BadRequest -> ErrorRepresentation(ErrorCodes.InvalidEntity, msg))
   }.handle {
-    case MalformedRequestContentRejection(_, DecodingFailure(msg, _)) =>
-      complete(StatusCodes.BadRequest -> ErrorRepresentation(ErrorCodes.InvalidEntity, msg))
+    case MalformedRequestContentRejection(_, df@DecodingFailure(_, _)) =>
+      complete(StatusCodes.BadRequest -> ErrorRepresentation(ErrorCodes.InvalidEntity, df.getMessage))
   }.handle {
-    case MalformedQueryParamRejection(name, msg, _) ⇒
+    case MalformedQueryParamRejection(name, _, _) ⇒
       complete(StatusCodes.BadRequest -> ErrorRepresentation(ErrorCodes.InvalidEntity, "The query parameter '" + name + "' was malformed"))
   }.result().withFallback(RejectionHandler.default)
 }


### PR DESCRIPTION
Also keep history in message from default rejection handler. Tested locally with the API provider.

Signed-off-by: Jochen Schneider <j.schneider@here.com>